### PR TITLE
Set up API endpoint for a site

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -1,0 +1,25 @@
+class Api::BaseController < ApplicationController
+  prepend_before_action :authenticate_api_token!
+
+  private
+
+  def authenticate_api_token!
+    @site = site_from_token
+    return head :unauthorized if !@site
+  end
+
+  def token_from_header
+    request.headers.fetch("Authorization", "").split(" ").last
+  end
+
+  def api_token
+    @_api_token ||= ApiToken.find_by(token: token_from_header)
+  end
+
+  def site_from_token
+    if api_token.present?
+      api_token.touch(:last_used_at)
+      api_token.site
+    end
+  end
+end

--- a/app/controllers/api/v1/site_controller.rb
+++ b/app/controllers/api/v1/site_controller.rb
@@ -1,0 +1,5 @@
+class Api::V1::SiteController < Api::BaseController
+  def show
+    render partial: "api/v1/sites/site", locals: {site: @site}
+  end
+end

--- a/app/models/api_token.rb
+++ b/app/models/api_token.rb
@@ -1,0 +1,7 @@
+class ApiToken < ApplicationRecord
+  belongs_to :site, dependent: :destroy
+
+  validates_presence_of :name
+
+  has_secure_token :token
+end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -1,4 +1,5 @@
 class Site < ApplicationRecord
   belongs_to :account
   has_many :pages
+  has_many :api_tokens
 end

--- a/app/views/api/v1/sites/_site.json.jbuilder
+++ b/app/views/api/v1/sites/_site.json.jbuilder
@@ -1,0 +1,3 @@
+json.cache! [site] do
+  json.extract! site, :id, :account_id, :created_at, :updated_at
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,10 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "home#index"
+
+  namespace :api, defaults: {format: :json} do
+    namespace :v1 do
+      resource :site, controller: :site
+    end
+  end
 end

--- a/db/migrate/20230714162858_create_api_tokens.rb
+++ b/db/migrate/20230714162858_create_api_tokens.rb
@@ -1,0 +1,14 @@
+class CreateApiTokens < ActiveRecord::Migration[7.0]
+  def change
+    create_table :api_tokens do |t|
+      t.references :site, null: false, foreign_key: true
+      t.string :name
+      t.string :token
+      t.datetime :expires_at
+      t.datetime :last_used_at
+
+      t.timestamps
+      t.index :token, unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,25 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_14_112846) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_14_162858) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "accounts", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "api_tokens", force: :cascade do |t|
+    t.bigint "site_id", null: false
+    t.string "name"
+    t.string "token"
+    t.datetime "expires_at"
+    t.datetime "last_used_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["site_id"], name: "index_api_tokens_on_site_id"
+    t.index ["token"], name: "index_api_tokens_on_token", unique: true
   end
 
   create_table "memberships", force: :cascade do |t|
@@ -56,6 +68,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_14_112846) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "api_tokens", "sites"
   add_foreign_key "memberships", "accounts"
   add_foreign_key "memberships", "users"
   add_foreign_key "pages", "sites", on_delete: :cascade

--- a/spec/models/api_token_spec.rb
+++ b/spec/models/api_token_spec.rb
@@ -1,0 +1,7 @@
+require "rails_helper"
+
+RSpec.describe ApiToken, type: :model do
+  it { should belong_to(:site).dependent(:destroy) }
+  it { should have_secure_token(:token) }
+  it { should validate_presence_of(:name) }
+end

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.describe Site, type: :model do
   it { should belong_to(:account) }
   it { should have_many(:pages) }
+  it { should have_many(:api_tokens) }
 
   it "is destroyed when parent account is destroyed" do
     account = Account.create!

--- a/spec/requests/api/base_controller_spec.rb
+++ b/spec/requests/api/base_controller_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.describe Api::BaseController, type: :request do
+  it "returns unauthorized if token is invalid" do
+    get "/api/v1/site", headers: {Authorization: "token 1234abc"}
+    expect(response).to have_http_status(:unauthorized)
+  end
+
+  it "returns 200 if token is valid" do
+    api_token = create_valid_api_token
+    get "/api/v1/site", headers: {Authorization: "token #{api_token.token}"}
+    expect(response).to have_http_status(:ok)
+  end
+
+  it "updates last_used_at for a valid token" do
+    api_token = create_valid_api_token
+
+    expect(api_token.last_used_at).to be_nil
+
+    get "/api/v1/site", headers: {Authorization: "token #{api_token.token}"}
+
+    expect(api_token.reload.last_used_at).not_to be_nil
+  end
+
+  def create_valid_api_token
+    account = Account.create!
+    site = Site.create!(account:)
+    site.api_tokens.create!(name: "name")
+  end
+end

--- a/spec/requests/api/v1/site_spec.rb
+++ b/spec/requests/api/v1/site_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+RSpec.describe Api::V1::SiteController, type: :request do
+  it "returns site details" do
+    account = Account.create!
+    site = Site.create!(account:)
+    api_token = site.api_tokens.create!(name: "name")
+
+    get "/api/v1/site", headers: {Authorization: "token #{api_token.token}"}
+
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body["id"]).to eq(site.id)
+    expect(response.parsed_body["created_at"]).not_to be_nil
+    expect(response.parsed_body["updated_at"]).not_to be_nil
+  end
+end


### PR DESCRIPTION
The goal here is to set up a simple authenticated API endpoint that can return site details. Eventually, this endpoint will provide data that can be used to construct elements on a webpage, e.g. a setting for a default title tag.

For now at least, we'll use an API token associated with a site, although it might make sense in the future to use an API token associated with a user. 

