### PR TITLE
Add site settings

### DIFF
--- a/app/views/api/v1/sites/_site.json.jbuilder
+++ b/app/views/api/v1/sites/_site.json.jbuilder
@@ -1,3 +1,3 @@
 json.cache! [site] do
-  json.extract! site, :id, :account_id, :created_at, :updated_at
+  json.extract! site, :id, :account_id, :settings, :created_at, :updated_at
 end

--- a/db/migrate/20230714200657_add_settings_to_sites.rb
+++ b/db/migrate/20230714200657_add_settings_to_sites.rb
@@ -1,0 +1,5 @@
+class AddSettingsToSites < ActiveRecord::Migration[7.0]
+  def change
+    add_column :sites, :settings, :jsonb, null: false, default: {}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_14_162858) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_14_200657) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -53,6 +53,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_14_162858) do
     t.bigint "account_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.jsonb "settings", default: {}, null: false
     t.index ["account_id"], name: "index_sites_on_account_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,13 @@
 #
 #   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
 #   Character.create(name: "Luke", movie: movies.first)
+
+if Rails.env.development?
+  site = Site.first
+
+  site.settings = {
+    a: 1
+  }
+
+  site.save!
+end

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -6,11 +6,20 @@ RSpec.describe Site, type: :model do
   it { should have_many(:api_tokens) }
 
   it "is destroyed when parent account is destroyed" do
-    account = Account.create!
-    site = account.sites.create!
-
-    Account.delete_all
-
+    site = create_site
+    Account.delete_all # bypass AR callbacks
     expect { Site.find(site.id) }.to raise_exception(ActiveRecord::RecordNotFound)
+  end
+
+  it "allows me to store arbitrary settings" do
+    site = create_site
+    expect(site.settings).to eq({})
+    site.update(settings: {field: "value"})
+    expect(site.reload.settings["field"]).to eq("value")
+  end
+
+  def create_site
+    account = Account.create!
+    account.sites.create!
   end
 end

--- a/spec/requests/api/v1/site_spec.rb
+++ b/spec/requests/api/v1/site_spec.rb
@@ -3,13 +3,15 @@ require "rails_helper"
 RSpec.describe Api::V1::SiteController, type: :request do
   it "returns site details" do
     account = Account.create!
-    site = Site.create!(account:)
+    site = Site.create!(account:, settings: {a: 1})
     api_token = site.api_tokens.create!(name: "name")
 
     get "/api/v1/site", headers: {Authorization: "token #{api_token.token}"}
 
     expect(response).to have_http_status(:ok)
     expect(response.parsed_body["id"]).to eq(site.id)
+    expect(response.parsed_body["account_id"]).to eq(account.id)
+    expect(response.parsed_body["settings"]).to eq({"a" => 1})
     expect(response.parsed_body["created_at"]).not_to be_nil
     expect(response.parsed_body["updated_at"]).not_to be_nil
   end


### PR DESCRIPTION
Adds a quick and dirty way to begin playing with returning site settings via the API. 

My best guess is we won't want a large `settings` column that contains everything -- if `settings` gets large, it will be painful to wrangle, especially if there are nested settings. 

But I don't want to pick the wrong abstraction, so a simple `jsonb` column should do for now. Once I have a better idea of all the possible settings a user might need, I'll refactor as necessary.